### PR TITLE
improvements in the benchmarks

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -76,11 +76,13 @@ func (c *converter) makeFields(v reflect.Value, prefix string) error {
 		}
 
 		structField := v.Type().Field(i)
-		if structField.Tag.Get(frameTag) == "-" {
+		fieldNameFromTag := structField.Tag.Get(frameTag)
+
+		if fieldNameFromTag == "-" {
 			continue
 		}
 
-		fieldName := c.fieldName(structField, prefix)
+		fieldName := c.fieldName(structField.Name, fieldNameFromTag, prefix)
 		switch field.Kind() {
 		case reflect.Struct:
 			c.makeFields(field, fieldName)
@@ -108,10 +110,10 @@ func (c *converter) createField(v reflect.Value, fieldName string) error {
 	return nil
 }
 
-func (c *converter) fieldName(v reflect.StructField, prefix string) string {
-	fName := v.Name
-	if tag := v.Tag.Get(frameTag); tag != "" {
-		fName = tag
+func (c *converter) fieldName(fieldName, fieldNameFromTag, prefix string) string {
+	fName := fieldName
+	if fieldNameFromTag != "" {
+		fName = fieldNameFromTag
 	}
 
 	if prefix == "" {

--- a/converter.go
+++ b/converter.go
@@ -13,7 +13,7 @@ type converter struct {
 	fields     map[string]*data.Field
 }
 
-// ToDataframe flattens an arbitrary struct or slice of sructs into a *data.Frame
+// ToDataframe flattens an arbitrary struct or slice of structs into a *data.Frame
 func ToDataframe(name string, toConvert interface{}) (*data.Frame, error) {
 	cr := &converter{
 		fields: make(map[string]*data.Field),
@@ -66,7 +66,7 @@ func (c *converter) convertField(f reflect.Value) error {
 
 func (c *converter) makeFields(v reflect.Value, prefix string) error {
 	if v.Kind() != reflect.Struct {
-		return errors.New("unspported type: cannot convert types witout fields")
+		return errors.New("unsupported type: cannot convert types without fields")
 	}
 
 	for i := 0; i < v.NumField(); i++ {

--- a/converter.go
+++ b/converter.go
@@ -2,10 +2,8 @@ package framestruct
 
 import (
 	"errors"
-	"fmt"
-	"reflect"
-
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"reflect"
 )
 
 const frameTag = "frame"
@@ -118,7 +116,8 @@ func (c *converter) fieldName(v reflect.StructField, prefix string) string {
 	if prefix == "" {
 		return fName
 	}
-	return fmt.Sprintf("%s.%s", prefix, fName)
+
+	return prefix + "." + fName
 }
 
 func (c *converter) ensureValue(v reflect.Value) reflect.Value {

--- a/converter.go
+++ b/converter.go
@@ -70,7 +70,8 @@ func (c *converter) makeFields(v reflect.Value, prefix string) error {
 	}
 
 	for i := 0; i < v.NumField(); i++ {
-		if !v.Field(i).CanInterface() {
+		field := v.Field(i)
+		if !field.CanInterface() {
 			continue
 		}
 
@@ -80,14 +81,14 @@ func (c *converter) makeFields(v reflect.Value, prefix string) error {
 		}
 
 		fieldName := c.fieldName(structField, prefix)
-		switch v.Field(i).Kind() {
+		switch field.Kind() {
 		case reflect.Struct:
-			c.makeFields(v.Field(i), fieldName)
+			c.makeFields(field, fieldName)
 		default:
-			if err := c.createField(v.Field(i), fieldName); err != nil {
+			if err := c.createField(field, fieldName); err != nil {
 				return err
 			}
-			c.fields[fieldName].Append(v.Field(i).Interface())
+			c.fields[fieldName].Append(field.Interface())
 		}
 	}
 	return nil

--- a/converter_bench_test.go
+++ b/converter_bench_test.go
@@ -1,16 +1,22 @@
 package framestruct_test
 
 import (
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"testing"
 	"time"
 
 	"github.com/masslessparticle/go-framestruct"
 )
 
+// This is here to avoid compiler optimizations that
+// could remove the actual call we are benchmarking
+// during benchmarks
+var benchmarkResult *data.Frame
+
 func benchMarshal(b *testing.B, v interface{}) {
 	b.Run("marshal", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			framestruct.ToDataframe("frame", v)
+			benchmarkResult, _ = framestruct.ToDataframe("frame", v)
 		}
 	})
 }


### PR DESCRIPTION
Before:

```bash
$ go test -bench=. -benchmem -run=^$
goarch: amd64
pkg: github.com/masslessparticle/go-framestruct
cpu: Intel(R) Core(TM) i5-8500 CPU @ 3.00GHz
BenchmarkMarshalTable_10/marshal-6                126786              9355 ns/op            3104 B/op         99 allocs/op
BenchmarkMarshalTable_100/marshal-6                16560             72396 ns/op           20336 B/op        648 allocs/op
BenchmarkMarshalTable_1000/marshal-6                1735            690775 ns/op          171152 B/op       6057 allocs/op
BenchmarkMarshalTable_10000/marshal-6                165           7195916 ns/op         3198808 B/op      60084 allocs/op
BenchmarkEmbeddedStruct_10/marshal-6              103455             11504 ns/op            3000 B/op        147 allocs/op
BenchmarkEmbeddedStruct_100/marshal-6              10000            103790 ns/op           22781 B/op       1233 allocs/op
BenchmarkEmbeddedStruct_1000/marshal-6              1159           1017648 ns/op          209837 B/op      12039 allocs/op
BenchmarkEmbeddedStruct_10000/marshal-6              100          10448728 ns/op         2813916 B/op     120061 allocs/op
PASS
ok      github.com/masslessparticle/go-framestruct      11.337s
```

After:

```bash
go test -bench=. -benchmem -run=^$
goos: darwin
goarch: amd64
pkg: github.com/masslessparticle/go-framestruct
cpu: Intel(R) Core(TM) i5-8500 CPU @ 3.00GHz
BenchmarkMarshalTable_10/marshal-6                152192              7771 ns/op            3104 B/op         99 allocs/op
BenchmarkMarshalTable_100/marshal-6                20836             58110 ns/op           20336 B/op        648 allocs/op
BenchmarkMarshalTable_1000/marshal-6                2067            549002 ns/op          171152 B/op       6057 allocs/op
BenchmarkMarshalTable_10000/marshal-6                199           5942379 ns/op         3198814 B/op      60084 allocs/op
BenchmarkEmbeddedStruct_10/marshal-6              158178              7455 ns/op            2360 B/op        107 allocs/op
BenchmarkEmbeddedStruct_100/marshal-6              19177             62640 ns/op           16376 B/op        833 allocs/op
BenchmarkEmbeddedStruct_1000/marshal-6              1994            603470 ns/op          145785 B/op       8039 allocs/op
BenchmarkEmbeddedStruct_10000/marshal-6              193           6203007 ns/op         2172929 B/op      80057 allocs/op
PASS
ok      github.com/masslessparticle/go-framestruct      12.337s

```